### PR TITLE
Fixed getting serial number

### DIFF
--- a/brother_ql/backends/pyusb.py
+++ b/brother_ql/backends/pyusb.py
@@ -47,7 +47,7 @@ def list_available_devices():
 
     def identifier(dev):
         try:
-            serial = usb.util.get_string(dev, 256, dev.iSerialNumber)
+            serial = usb.util.get_string(dev, dev.iSerialNumber)
             return 'usb://0x{:04x}:0x{:04x}_{}'.format(dev.idVendor, dev.idProduct, serial)
         except:
             return 'usb://0x{:04x}:0x{:04x}'.format(dev.idVendor, dev.idProduct)


### PR DESCRIPTION
For some reason the serial was some unicode garbage. Needed a fix since I need more than on printer of the same model.