### PR TITLE
fix broken --version option

### DIFF
--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -25,7 +25,7 @@ printer_help = "The identifier for the printer. This could be a string like tcp:
 @click.option('-m', '--model', type=click.Choice(ModelsManager().identifiers()), envvar='BROTHER_QL_MODEL')
 @click.option('-p', '--printer', metavar='PRINTER_IDENTIFIER', envvar='BROTHER_QL_PRINTER', help=printer_help)
 @click.option('--debug', is_flag=True)
-@click.version_option()
+@click.version_option(package_name='brother_ql_next')
 @click.pass_context
 def cli(ctx: click.Context, *args, **kwargs):
     """ Command line interface for the brother_ql Python package. """


### PR DESCRIPTION
Since the binary is named `brother_ql` but the distribution name is `brother_ql_next`, click's `version_option` function isn't able to detect the version by default. This is resolved by specifying the `package_name` argument to said function.

This remedies some of the odd behavior seen in https://github.com/LunarEclipse363/brother_ql_next/issues/11
