### PR TITLE
remove unused deps, switch to non-deprecated license spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,18 +10,15 @@ authors = [
 maintainers = [
     { name = "LunarEclipse", email = "luna@lunareclipse.zone" },
 ]
-license = { text = "GPL-3.0-only" }
+license = "GPL-3.0-only"
 requires-python = ">=3.9"
 dependencies = [
+    "attrs",
     "click",
-    "future",
+    "jsons",
     "packbits",
     "pillow>=3.3.0",
     "pyusb",
-    "attrs",
-    "typing;python_version<\"3.5\"",
-    "enum34;python_version<\"3.4\"",
-    "jsons",
 ]
 keywords = [
     "Brother",
@@ -47,7 +44,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Visualization",


### PR DESCRIPTION
Removing the unused (based on requiring python 3.9, so 2/3 compatibility seems moot?) `future` dependency allows the project to be built with Python 3.13.

The changes to the license specification and the removal of the license classifier aligns to current guidance ([PEP 639](https://peps.python.org/pep-0639/)). This change is supported for building with setuptools 77.0.3 or later.
